### PR TITLE
Automate updating plugins.php

### DIFF
--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -23,7 +23,8 @@ class PluginInstaller extends LibraryInstaller
     {
         parent::installCode($package);
         $path = $this->getInstallPath($package);
-        $this->updateConfig($package->getName(), $path);
+        $ns = $this->primaryNamespace($package);
+        $this->updateConfig($ns, $path);
     }
 
     /**
@@ -33,7 +34,8 @@ class PluginInstaller extends LibraryInstaller
     {
         parent::updateCode($initial, $target);
         $path = $this->getInstallPath($package);
-        $this->updateConfig($package->getName(), $path);
+        $ns = $this->primaryNamespace($package);
+        $this->updateConfig($ns, $path);
     }
 
     /**
@@ -43,7 +45,8 @@ class PluginInstaller extends LibraryInstaller
     {
         parent::removeCode($package);
         $path = $this->getInstallPath($package);
-        $this->updateConfig($package->getName(), null);
+        $ns = $this->primaryNamespace($package);
+        $this->updateConfig($ns, null);
     }
 
     /**
@@ -92,7 +95,7 @@ class PluginInstaller extends LibraryInstaller
                 )
             );
         }
-        return $primaryNs;
+        return trim($primaryNs, '\\');
     }
 
     /**
@@ -121,6 +124,11 @@ class PluginInstaller extends LibraryInstaller
         if ($path == null) {
             unset($config['plugins'][$name]);
         } else {
+            $path = str_replace(
+                DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR,
+                DIRECTORY_SEPARATOR,
+                $path . DIRECTORY_SEPARATOR
+            );
             $config['plugins'][$name] = $path;
         }
         $this->writeConfig($configFile, $config);

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -59,9 +59,9 @@ class PluginInstaller extends LibraryInstaller
         if (!$primaryNS) {
             throw new RuntimeException(
                 sprintf(
-                	"Unable to get plugin name for package %s. 
-                	Ensure you have added proper 'autoload' section to your plugin's config as stated in README on https://github.com/cakephp/plugin-installer", 
-                	$package->getName()
+                    "Unable to get plugin name for package %s. 
+                    Ensure you have added proper 'autoload' section to your plugin's config as stated in README on https://github.com/cakephp/plugin-installer",
+                    $package->getName()
                 )
             );
         }

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -39,6 +39,79 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $this->installer = new PluginInstaller($io, $composer);
     }
 
+    public function testPrimaryNamespace()
+    {
+        $autoload = array(
+            'psr-4' => array(
+                'FOC\\Authenticate' => ''
+            )
+        );
+        $this->package->setAutoload($autoload);
+
+        $name = $this->installer->primaryNamespace($this->package);
+        $this->assertEquals('FOC\Authenticate', $name);
+
+        $autoload = array(
+            'psr-4' => array(
+                'FOC\Acl\Test' => './tests',
+                'FOC\Acl' => ''
+            )
+        );
+        $this->package->setAutoload($autoload);
+        $name = $this->installer->primaryNamespace($this->package);
+        $this->assertEquals('FOC\Acl', $name);
+
+        $autoload = array(
+            'psr-4' => array(
+                'Foo\Bar' => 'foo',
+                'Acme\Plugin' => './src'
+            )
+        );
+        $this->package->setAutoload($autoload);
+        $name = $this->installer->primaryNamespace($this->package);
+        $this->assertEquals('Acme\Plugin', $name);
+
+        $autoload = array(
+            'psr-4' => array(
+                'Foo\Bar' => 'bar',
+                'Foo' => ''
+            )
+        );
+        $this->package->setAutoload($autoload);
+        $name = $this->installer->primaryNamespace($this->package);
+        $this->assertEquals('Foo', $name);
+
+        $autoload = array(
+            'psr-4' => array(
+                'Foo\Bar' => 'bar',
+                'Foo' => '.'
+            )
+        );
+        $this->package->setAutoload($autoload);
+        $name = $this->installer->primaryNamespace($this->package);
+        $this->assertEquals('Foo', $name);
+
+        $autoload = array(
+            'psr-4' => array(
+                'Acme\Foo\Bar' => 'bar',
+                'Acme\Foo' => ''
+            )
+        );
+        $this->package->setAutoload($autoload);
+        $name = $this->installer->primaryNamespace($this->package);
+        $this->assertEquals('Acme\Foo', $name);
+
+        $autoload = array(
+            'psr-4' => array(
+                'Acme\Foo\Bar' => '',
+                'Acme\Foo' => 'src'
+            )
+        );
+        $this->package->setAutoload($autoload);
+        $name = $this->installer->primaryName($this->package);
+        $this->assertEquals('Acme\Foo', $name);
+    }
+
     /**
      * Test install path
      *

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -97,7 +97,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $autoload = array(
             'psr-4' => array(
                 'Foo\Bar' => 'bar',
-                'Foo' => ''
+                'Foo\\' => ''
             )
         );
         $this->package->setAutoload($autoload);
@@ -117,7 +117,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $autoload = array(
             'psr-4' => array(
                 'Acme\Foo\Bar' => 'bar',
-                'Acme\Foo' => ''
+                'Acme\Foo\\' => ''
             )
         );
         $this->package->setAutoload($autoload);
@@ -142,7 +142,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $contents = file_get_contents($this->path . '/config/plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'plugins' =>", $contents);
-        $this->assertContains("'DebugKit' => '/vendor/cakephp/DebugKit'", $contents);
+        $this->assertContains("'DebugKit' => '/vendor/cakephp/DebugKit/'", $contents);
     }
 
     public function testUpdateConfigAddPathInvalidFile()
@@ -162,7 +162,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $contents = file_get_contents($this->path . '/config/plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'plugins' =>", $contents);
-        $this->assertContains("'DebugKit' => '/vendor/cakephp/DebugKit'", $contents);
+        $this->assertContains("'DebugKit' => '/vendor/cakephp/DebugKit/'", $contents);
         $this->assertContains("'Bake' => '/some/path'", $contents);
     }
 


### PR DESCRIPTION
This is the complementary change to cakephp/cakephp#5641. When plugins are installed with composer, they will now be put in `/vendor` like all other vendor code. In addition to that, the `/config/plugins.php` file that CakePHP will start using will also be updated. 

All of this lets vendor plugins work seamlessly without any incompatible changes that I can think of. It also frees up `/plugins` to be for in-app plugins and removes the need to bootstrap a second plugin path.