### PR TITLE
Corrects an issue with absolute paths being used as relative path.

### DIFF
--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -204,7 +204,9 @@ PHP;
      */
     protected function writeConfig($path, $config)
     {
+        $root = dirname($this->vendorDir);
         $contents = '<?php' . "\n" . 'return ' . var_export($config, true) . ';';
+        $contents = str_replace($root, '', $contents);
         file_put_contents($path, $contents);
     }
 }

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -181,6 +181,7 @@ class PluginInstaller extends LibraryInstaller
         }
         $contents = <<<'PHP'
 <?php
+$baseDir = dirname(dirname(__FILE__));
 return [
     'plugins' => []
 ];
@@ -205,8 +206,8 @@ PHP;
     protected function writeConfig($path, $config)
     {
         $root = dirname($this->vendorDir);
-        $contents = '<?php' . "\n" . 'return ' . var_export($config, true) . ';';
-        $contents = str_replace($root, '', $contents);
+        $contents = '<?php' . "\n" . '$baseDir = dirname(dirname(__FILE__));' . "\n" . 'return ' . var_export($config, true) . ';';
+        $contents = str_replace('\'' . $root, '$baseDir . \'', $contents);
         file_put_contents($path, $contents);
     }
 }

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -166,6 +166,21 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * testUpdateConfigAddRootPath
+     *
+     * @return void
+     */
+    public function testUpdateConfigAddRootPath() {
+        file_put_contents($this->path . '/config/plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
+
+        $this->installer->updateConfig('DebugKit', sys_get_temp_dir() . '/vendor/cakephp/debugkit');
+        $contents = file_get_contents($this->path . '/config/plugins.php');
+        $this->assertContains('<?php', $contents);
+        $this->assertContains("'DebugKit' => '/vendor/cakephp/debugkit/'", $contents);
+        $this->assertContains("'Bake' => '/some/path'", $contents);
+    }
+
+    /**
      * testUpdateConfigAddPath
      *
      * @return void

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -176,7 +176,8 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $this->installer->updateConfig('DebugKit', sys_get_temp_dir() . '/vendor/cakephp/debugkit');
         $contents = file_get_contents($this->path . '/config/plugins.php');
         $this->assertContains('<?php', $contents);
-        $this->assertContains("'DebugKit' => '/vendor/cakephp/debugkit/'", $contents);
+        $this->assertContains('$baseDir = dirname(dirname(__FILE__));', $contents);
+        $this->assertContains("'DebugKit' => \$baseDir . '/vendor/cakephp/debugkit/'", $contents);
         $this->assertContains("'Bake' => '/some/path'", $contents);
     }
 


### PR DESCRIPTION
When running composer in one location (e.g. on the host), and running the webserver on another location (e.g. Vagrant box), the installer would use the absolute host path (`/home/<user>/development/site/vendor/cakephp/debug_kit` for example), this has results in the `Plugin` class not being able to find the plugin files.

Correct this by replacing the root directory with blank when writing out the config.