### PR TITLE
Fix plugin name for plugins with vendor name in top level namespace.

### DIFF
--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -117,7 +117,7 @@ class PluginInstaller extends LibraryInstaller
         if (!$primaryNs) {
             throw new RuntimeException(
                 sprintf(
-                    "Unable to get primary namespace for package %s. 
+                    "Unable to get primary namespace for package %s.
                     Ensure you have added proper 'autoload' section to your plugin's config as stated in README on https://github.com/cakephp/plugin-installer",
                     $package->getName()
                 )
@@ -134,6 +134,7 @@ class PluginInstaller extends LibraryInstaller
      */
     public function updateConfig($name, $path)
     {
+        $name = str_replace('\\', '/', $name);
         $root = dirname($this->vendorDir);
         $configFile = $root . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'plugins.php';
         $this->ensureConfigFile($configFile);

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -191,10 +191,13 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         file_put_contents($this->path . '/config/plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
 
         $this->installer->updateConfig('DebugKit', '/vendor/cakephp/debugkit');
+        $this->installer->updateConfig('ADmad\JwtAuth', '/vendor/admad/cakephp-jwt-auth');
+
         $contents = file_get_contents($this->path . '/config/plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'DebugKit' => '/vendor/cakephp/debugkit/'", $contents);
         $this->assertContains("'Bake' => '/some/path'", $contents);
+        $this->assertContains("'ADmad/JwtAuth' => '/vendor/admad/cakephp-jwt-auth/'", $contents);
     }
 
     /**


### PR DESCRIPTION
Plugin::load() expects forward slash in plugin name.

Refs cakephp/cakephp#5671