### PR TITLE
Ensure there's a newline at the end of the file

### DIFF
--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -214,7 +214,7 @@ PHP;
         $root = dirname($this->vendorDir);
         $contents = '<?php' . "\n" .
             '$baseDir = dirname(dirname(__FILE__));' . "\n" .
-            'return ' . var_export($config, true) . ';';
+            'return ' . var_export($config, true) . ";\n";
         $contents = str_replace('\'' . $root, '$baseDir . \'', $contents);
         file_put_contents($path, $contents);
     }


### PR DESCRIPTION
Otherwise it's a phpcs fail and generally a bit irritating.

Should we implement `assertSameAsFile`? Would have made this obvious/caused test fails.