### PR TITLE
Dump autoload hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
   - 5.4
   - 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,15 @@ php:
 matrix:
   allow_failures:
     - php: hhvm-nightly
+  include:
+    - php: 5.4
+      env: PHPCS=1
 
 before_script: composer install --prefer-dist --dev
 
-script: phpunit
+script:
+  - sh -c "if [ '$PHPCS' != '1' ]; then phpunit; fi"
+  - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -p -n --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,11 @@
             "Cake\\Composer\\": "src/"
         }
     },
+	"autoload-dev": {
+		"psr-4": {
+			"Cake\\Test\\Composer\\": "tests"
+        }
+    },
     "extra": {
         "class": "Cake\\Composer\\Installer\\PluginInstaller"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require-dev": {
         "composer/composer": "1.0.*@dev",
-        "cakephp/core": "dev-master",
         "cakephp/cakephp-codesniffer": "dev-master"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
             "Cake\\Composer\\": "src/"
         }
     },
-	"autoload-dev": {
-		"psr-4": {
-			"Cake\\Test\\Composer\\": "tests"
+    "autoload-dev": {
+        "psr-4": {
+            "Cake\\Test\\Composer\\": "tests"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require-dev": {
         "composer/composer": "1.0.*@dev",
-        "cakephp/core": "dev-master"
+        "cakephp/core": "dev-master",
+        "cakephp/cakephp-codesniffer": "dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -61,16 +61,25 @@ class PluginInstaller extends LibraryInstaller
             !isset($scripts['post-autoload-dump']) ||
             !in_array($postAutoloadDump, $scripts['post-autoload-dump'])
         ) {
-            $this->warnUpdateRequired();
+            $this->warnUser(
+                'Action required!',
+                'The CakePHP plugin installer has been changed, please update your' .
+                ' application composer.json file to add the post-autoload-dump hook.' .
+                ' See the changes in https://github.com/cakephp/app/pull/216 for more' .
+                ' info.'
+            );
         }
     }
 
     /**
-     * Warn the developer they need to update their root composer.json file
+     * Warn the developer of action they need to take
+     *
+     * @param string $title Warning title
+     * @param string $text warning text
      *
      * @return void
      */
-    public function warnUpdateRequired()
+    public function warnUser($title, $text)
     {
         $wrap = function ($text, $width = 75) {
             return '<error>     ' . str_pad($text, $width) . '</error>';
@@ -80,16 +89,16 @@ class PluginInstaller extends LibraryInstaller
             '',
             '',
             $wrap(''),
-            $wrap('Action required!'),
+            $wrap($title),
             $wrap(''),
-            $wrap('The CakePHP plugin installer has been changed, please update your'),
-            $wrap('application composer.json file to add the post-autoload-dump hook.'),
-            $wrap('See the changes in https://github.com/cakephp/app/pull/216 for more'),
-            $wrap('info.'),
-            $wrap(''),
-            '',
-            '',
         ];
+
+        $lines = explode("\n", wordwrap($text, 68));
+        foreach ($lines as $line) {
+            $messages[] = $wrap($line);
+        }
+
+        $messages = array_merge($messages, [$wrap(''), '', '']);
 
         $this->io->write($messages);
     }

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -21,14 +21,7 @@ class PluginInstaller extends LibraryInstaller
     protected static $checkUsage = true;
 
     /**
-     * io instance
-     *
-     * @var \Composer\IO\IOInterface
-     */
-    protected $io;
-
-    /**
-     * Store a reference to the io for warnings
+     * Check usage upon construction
      *
      * @param IOInterface $io
      * @param Composer    $composer
@@ -38,7 +31,6 @@ class PluginInstaller extends LibraryInstaller
     public function __construct(IOInterface $io, Composer $composer, $type = 'library', Filesystem $filesystem = null)
     {
         parent::__construct($io, $composer, $type, $filesystem);
-        $this->io = $io;
         $this->checkUsage($composer);
     }
 

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -17,9 +17,8 @@ class PluginInstaller extends LibraryInstaller
      * A flag to check usage - once
      *
      * @var bool
-     * @access public
      */
-    static $checkUsage = true;
+    protected static $checkUsage = true;
 
     /**
      * io instance
@@ -52,7 +51,8 @@ class PluginInstaller extends LibraryInstaller
      * @param Composer $composer
      * @return void
      */
-    public function checkUsage(Composer $composer) {
+    public function checkUsage(Composer $composer)
+    {
         if (static::$checkUsage === false) {
             return;
         }

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -91,6 +91,15 @@ $data
 ];
 
 PHP;
+
+        $root = str_replace(
+            DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR,
+            DIRECTORY_SEPARATOR,
+            $root
+        );
+
+        // Normalize to *nix paths.
+        $root = str_replace('\\', '/', $root);
         $contents = str_replace('\'' . $root, '$baseDir . \'', $contents);
         file_put_contents($configFile, $contents);
     }

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -386,6 +386,8 @@ PHP;
     /**
      * Ensure that the vendor/cakephp-plugins.php file exists.
      *
+     * If config/plugins.php is found - copy it to the vendors folder
+     *
      * @param string $path the config file path.
      * @return void
      */
@@ -394,6 +396,15 @@ PHP;
         if (file_exists($path)) {
             if ($this->io->isVerbose()) {
                 $this->io->write('vendor/cakephp-plugins.php exists.');
+            }
+            return;
+        }
+
+        $oldPath = dirname(dirname($path)) . DIRECTORY_SEPARATOR . 'config'. DIRECTORY_SEPARATOR . 'plugins.php';
+        if (file_exists($oldPath)) {
+            copy($oldPath, $path);
+            if ($this->io->isVerbose()) {
+                $this->io->write('config/plugins.php found and copied to vendor/cakephp-plugins.php.');
             }
             return;
         }

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -217,7 +217,7 @@ PHP;
      */
     protected static function configFile($root)
     {
-        return $root . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'plugins.php';
+        return $root . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'cakephp-plugins.php';
     }
 
     /**
@@ -284,7 +284,7 @@ PHP;
     /**
      * Installs specific plugin.
      *
-     * After the plugin is installed, app's `plugins.php` config file is updated with
+     * After the plugin is installed, app's `cakephp-plugins.php` config file is updated with
      * plugin namespace to path mapping.
      *
      * @param \Composer\Repository\InstalledRepositoryInterface $repo Repository in which to check.
@@ -302,7 +302,7 @@ PHP;
     /**
      * Updates specific plugin.
      *
-     * After the plugin is installed, app's `plugins.php` config file is updated with
+     * After the plugin is installed, app's `cakephp-plugins.php` config file is updated with
      * plugin namespace to path mapping.
      *
      * @param \Composer\Repository\InstalledRepositoryInterface $repo Repository in which to check.
@@ -357,7 +357,7 @@ PHP;
         }
         if (!isset($config)) {
             $this->io->write(
-                'ERROR - Your `vendor/plugins.php` did not define a $config variable. ' .
+                'ERROR - Your `vendor/cakephp-plugins.php` did not define a $config variable. ' .
                 'Plugin path configuration not updated.'
             );
             return;
@@ -384,7 +384,7 @@ PHP;
     }
 
     /**
-     * Ensure that the vendor/plugins.php file exists.
+     * Ensure that the vendor/cakephp-plugins.php file exists.
      *
      * @param string $path the config file path.
      * @return void
@@ -393,10 +393,11 @@ PHP;
     {
         if (file_exists($path)) {
             if ($this->io->isVerbose()) {
-                $this->io->write('vendor/plugins.php exists.');
+                $this->io->write('vendor/cakephp-plugins.php exists.');
             }
             return;
         }
+
         $contents = <<<'PHP'
 <?php
 $baseDir = dirname(dirname(__FILE__));
@@ -410,7 +411,7 @@ PHP;
         file_put_contents($path, $contents);
 
         if ($this->io->isVerbose()) {
-            $this->io->write('Created vendor/plugins.php');
+            $this->io->write('Created vendor/cakephp-plugins.php');
         }
     }
 

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -23,10 +23,10 @@ class PluginInstaller extends LibraryInstaller
     /**
      * Check usage upon construction
      *
-     * @param IOInterface $io
-     * @param Composer    $composer
-     * @param string      $type
-     * @param Filesystem  $filesystem
+     * @param IOInterface $io composer object
+     * @param Composer    $composer composer object
+     * @param string      $type what are we loading
+     * @param Filesystem  $filesystem composer object
      */
     public function __construct(IOInterface $io, Composer $composer, $type = 'library', Filesystem $filesystem = null)
     {
@@ -73,7 +73,7 @@ class PluginInstaller extends LibraryInstaller
      */
     public function warnUpdateRequired()
     {
-        $wrap = function($text, $width = 75) {
+        $wrap = function ($text, $width = 75) {
             return '<error>     ' . str_pad($text, $width) . '</error>';
         };
 
@@ -101,7 +101,7 @@ class PluginInstaller extends LibraryInstaller
      * Recreates CakePHP's plugin path map, based on composer information
      * and available app-plugins.
      *
-     * @param Event $event
+     * @param Event $event the composer event object
      * @return void
      */
     public static function postAutoloadDump(Event $event)
@@ -117,7 +117,7 @@ class PluginInstaller extends LibraryInstaller
 
         $plugins = static::determinePlugins($packages, $pluginsDir, $vendorsDir);
 
-        $configFile = static::configFile($root);
+        $configFile = static::_configFile($root);
         static::writeConfigFile($configFile, $plugins);
     }
 
@@ -165,8 +165,8 @@ class PluginInstaller extends LibraryInstaller
     /**
      * Rewrite the config file with a complete list of plugins
      *
-     * @param string $configFile
-     * @param array $plugins
+     * @param string $configFile the path to the config file
+     * @param array $plugins of plugins
      * @return void
      */
     public static function writeConfigFile($configFile, $plugins)
@@ -218,7 +218,7 @@ PHP;
      *
      * @return string absolute file path
      */
-    protected static function configFile($root)
+    protected static function _configFile($root)
     {
         return $root . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'cakephp-plugins.php';
     }
@@ -226,7 +226,7 @@ PHP;
     /**
      * Get the primary namespace for a plugin package.
      *
-     * @param \Composer\Package\PackageInterface $package
+     * @param \Composer\Package\PackageInterface $package composer object
      * @return string The package's primary namespace.
      * @throws \RuntimeException When the package's primary namespace cannot be determined.
      */
@@ -352,8 +352,8 @@ PHP;
     public function updateConfig($name, $path)
     {
         $name = str_replace('\\', '/', $name);
-        $configFile = static::configFile(dirname($this->vendorDir));
-        $this->ensureConfigFile($configFile);
+        $configFile = static::_configFile(dirname($this->vendorDir));
+        $this->_ensureConfigFile($configFile);
 
         $return = include $configFile;
         if (is_array($return) && empty($config)) {
@@ -384,7 +384,7 @@ PHP;
 
             $config['plugins'][$name] = $path;
         }
-        $this->writeConfig($configFile, $config);
+        $this->_writeConfig($configFile, $config);
     }
 
     /**
@@ -395,7 +395,7 @@ PHP;
      * @param string $path the config file path.
      * @return void
      */
-    protected function ensureConfigFile($path)
+    protected function _ensureConfigFile($path)
     {
         if (file_exists($path)) {
             if ($this->io->isVerbose()) {
@@ -404,7 +404,7 @@ PHP;
             return;
         }
 
-        $oldPath = dirname(dirname($path)) . DIRECTORY_SEPARATOR . 'config'. DIRECTORY_SEPARATOR . 'plugins.php';
+        $oldPath = dirname(dirname($path)) . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'plugins.php';
         if (file_exists($oldPath)) {
             copy($oldPath, $path);
             if ($this->io->isVerbose()) {
@@ -437,7 +437,7 @@ PHP;
      * @param array $config The config data to write.
      * @return void
      */
-    protected function writeConfig($path, $config)
+    protected function _writeConfig($path, $config)
     {
         $root = dirname($this->vendorDir);
         $data = '';

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -75,7 +75,7 @@ class PluginInstaller extends LibraryInstaller
     }
 
     /**
-     * Warn the developer they need to update their root comopser.json file
+     * Warn the developer they need to update their root composer.json file
      *
      * @return void
      */

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -60,7 +60,7 @@ class PluginInstaller extends LibraryInstaller
 
         $root = $composer->getPackage();
 
-        if ($root->getType() !== 'project') {
+        if (!$root || $root->getType() !== 'project') {
             return;
         }
 

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -34,7 +34,7 @@ class PluginInstaller extends LibraryInstaller
         $plugins = static::determinePlugins($packages, $pluginsDir, $vendorsDir);
 
         $configFile = static::configFile($root);
-        static::overwriteConfigFile($configFile, $plugins);
+        static::writeConfigFile($configFile, $plugins);
     }
 
     /**
@@ -48,7 +48,7 @@ class PluginInstaller extends LibraryInstaller
      * @param string $vendorsDir the path to the vendors dir
      * @return array plugin-name indexed paths to plugins
      */
-    public static function determinePlugins($packages, $pluginsDir, $vendorsDir)
+    public static function determinePlugins($packages, $pluginsDir = 'plugins', $vendorsDir = 'vendors')
     {
         $plugins = [];
 
@@ -62,14 +62,16 @@ class PluginInstaller extends LibraryInstaller
             $plugins[$ns] = $path;
         }
 
-        $dir = new \DirectoryIterator($pluginsDir);
-        foreach($dir as $info) {
-            if (!$info->isDir() || $info->isDot()) {
-                continue;
-            }
+        if (is_dir($pluginsDir)) {
+            $dir = new \DirectoryIterator($pluginsDir);
+            foreach($dir as $info) {
+                if (!$info->isDir() || $info->isDot()) {
+                    continue;
+                }
 
-            $name = $info->getFilename();
-            $plugins[$name] = $pluginsDir . DIRECTORY_SEPARATOR . $name;
+                $name = $info->getFilename();
+                $plugins[$name] = $pluginsDir . DIRECTORY_SEPARATOR . $name;
+            }
         }
 
         ksort($plugins);
@@ -83,7 +85,7 @@ class PluginInstaller extends LibraryInstaller
      * @param array $plugins
      * @return void
      */
-    public static function overwriteConfigFile($configFile, $plugins)
+    public static function writeConfigFile($configFile, $plugins)
     {
         $root = dirname(dirname($configFile));
 

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -1,15 +1,33 @@
 <?php
 namespace Cake\Composer\Installer;
 
-use Composer\Script\Event;
 use Cake\Core\Configure\Engine\PhpConfig;
+use Composer\Composer;
+use Composer\IO\IOInterface;
 use Composer\Installer\LibraryInstaller;
 use Composer\Package\PackageInterface;
 use Composer\Repository\InstalledRepositoryInterface;
+use Composer\Script\Event;
+use Composer\Util\Filesystem;
 use RuntimeException;
 
 class PluginInstaller extends LibraryInstaller
 {
+    protected $io;
+
+    /**
+     * Store a reference to the io for warnings
+     *
+     * @param IOInterface $io
+     * @param Composer    $composer
+     * @param string      $type
+     * @param Filesystem  $filesystem
+     */
+    public function __construct(IOInterface $io, Composer $composer, $type = 'library', Filesystem $filesystem = null)
+    {
+        $this->io = $io;
+        parent::__construct($io, $composer, $type, $filesystem);
+    }
 
     /**
      * Called whenever composer (re)generates the autoloader
@@ -189,6 +207,32 @@ PHP;
     }
 
     /**
+     * warnDeprecated
+     *
+     * @return void
+     */
+	public function warnDeprecated()
+	{
+        $emptyLine = sprintf('<error>%s</error>', str_repeat(' ', 80));
+
+        $messages = [
+            '',
+            '',
+            $emptyLine,
+            '<error>     ' . str_pad('Deprecated usage!', 75) . '</error>',
+            $emptyLine,
+            '<error>     ' . str_pad('The CakePHP installer has been changed, please update your composer', 75) . '</error>',
+            '<error>     ' . str_pad('file to remove post-install-cmd and add post-autoload-dump hook instead.', 75) . '</error>',
+            '<error>     ' . str_pad('See the changes in https://github.com/cakephp/app/pull/216 for more info.', 75) . '</error>',
+            $emptyLine,
+            '',
+            '',
+        ];
+
+        $this->io->write($messages);
+	}
+
+    /**
      * Decides if the installer supports the given type.
      *
      * This installer only supports package of type 'cakephp-plugin'.
@@ -208,9 +252,11 @@ PHP;
      *
      * @param \Composer\Repository\InstalledRepositoryInterface $repo Repository in which to check.
      * @param \Composer\Package\PackageInterface $package Package instance.
+     * @deprecated use of the post-install-cmd hook is superceeded by the post-autoload-dump hook
      */
     public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
+		$this->warnDeprecated();
         parent::install($repo, $package);
         $path = $this->getInstallPath($package);
         $ns = static::primaryNamespace($package);
@@ -226,11 +272,13 @@ PHP;
      * @param \Composer\Repository\InstalledRepositoryInterface $repo Repository in which to check.
      * @param \Composer\Package\PackageInterface $initial Already installed package version.
      * @param \Composer\Package\PackageInterface $target Updated version.
+     * @deprecated use of the post-install-cmd hook is superceeded by the post-autoload-dump hook
      *
      * @throws \InvalidArgumentException if $initial package is not installed
      */
     public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target)
     {
+		$this->warnDeprecated();
         parent::update($repo, $initial, $target);
 
         $ns = static::primaryNamespace($initial);
@@ -246,9 +294,11 @@ PHP;
      *
      * @param \Composer\Repository\InstalledRepositoryInterface $repo Repository in which to check.
      * @param \Composer\Package\PackageInterface $package Package instance.
+     * @deprecated use of the post-install-cmd hook is superceeded by the post-autoload-dump hook
      */
     public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
+		$this->warnDeprecated();
         parent::uninstall($repo, $package);
         $path = $this->getInstallPath($package);
         $ns = static::primaryNamespace($package);

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -263,8 +263,9 @@ PHP;
         if (!$primaryNs) {
             throw new RuntimeException(
                 sprintf(
-                    "Unable to get primary namespace for package %s.
-                    Ensure you have added proper 'autoload' section to your plugin's config as stated in README on https://github.com/cakephp/plugin-installer",
+                    "Unable to get primary namespace for package %s." .
+                    "\nEnsure you have added proper 'autoload' section to your plugin's config" .
+                    " as stated in README on https://github.com/cakephp/plugin-installer",
                     $package->getName()
                 )
             );

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -50,9 +50,9 @@ class PluginInstaller extends LibraryInstaller
         }
         static::$checkUsage = false;
 
-        $root = $composer->getPackage();
+        $package = $composer->getPackage();
 
-        if (!$root || $root->getType() !== 'project') {
+        if (!$package || $package->getType() !== 'project') {
             return;
         }
 
@@ -110,14 +110,13 @@ class PluginInstaller extends LibraryInstaller
         $config = $composer->getConfig();
 
         $vendorDir = $config->get('vendor-dir');
-        $root = dirname($vendorDir);
 
         $packages = $composer->getRepositoryManager()->getLocalRepository()->getPackages();
-        $pluginsDir = $root . DIRECTORY_SEPARATOR . 'plugins';
+        $pluginsDir = dirname($vendorDir) . DIRECTORY_SEPARATOR . 'plugins';
 
         $plugins = static::determinePlugins($packages, $pluginsDir, $vendorDir);
 
-        $configFile = static::_configFile($root);
+        $configFile = static::_configFile($vendorDir);
         static::writeConfigFile($configFile, $plugins);
     }
 
@@ -216,11 +215,12 @@ PHP;
     /**
      * Path to the plugin config file
      *
+     * @param string $vendorDir path to composer-vendor dir
      * @return string absolute file path
      */
-    protected static function _configFile($root)
+    protected static function _configFile($vendorDir)
     {
-        return $root . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'cakephp-plugins.php';
+        return $vendorDir . DIRECTORY_SEPARATOR . 'cakephp-plugins.php';
     }
 
     /**
@@ -352,7 +352,7 @@ PHP;
     public function updateConfig($name, $path)
     {
         $name = str_replace('\\', '/', $name);
-        $configFile = static::_configFile(dirname($this->vendorDir));
+        $configFile = static::_configFile($this->vendorDir);
         $this->_ensureConfigFile($configFile);
 
         $return = include $configFile;

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -361,7 +361,7 @@ PHP;
         }
         if (!isset($config)) {
             $this->io->write(
-                'ERROR - Your `vendor/cakephp-plugins.php` did not define a $config variable. ' .
+                'ERROR - `vendor/cakephp-plugins.php` file is invalid. ' .
                 'Plugin path configuration not updated.'
             );
             return;

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -109,13 +109,13 @@ class PluginInstaller extends LibraryInstaller
         $composer = $event->getComposer();
         $config = $composer->getConfig();
 
-        $vendorsDir = $config->get('vendor-dir');
-        $root = dirname($vendorsDir);
+        $vendorDir = $config->get('vendor-dir');
+        $root = dirname($vendorDir);
 
         $packages = $composer->getRepositoryManager()->getLocalRepository()->getPackages();
         $pluginsDir = $root . DIRECTORY_SEPARATOR . 'plugins';
 
-        $plugins = static::determinePlugins($packages, $pluginsDir, $vendorsDir);
+        $plugins = static::determinePlugins($packages, $pluginsDir, $vendorDir);
 
         $configFile = static::_configFile($root);
         static::writeConfigFile($configFile, $plugins);
@@ -129,10 +129,10 @@ class PluginInstaller extends LibraryInstaller
      *
      * @param array $packages an array of \Composer\Package\PackageInterface objects
      * @param string $pluginsDir the path to the plugins dir
-     * @param string $vendorsDir the path to the vendors dir
+     * @param string $vendorDir the path to the vendor dir
      * @return array plugin-name indexed paths to plugins
      */
-    public static function determinePlugins($packages, $pluginsDir = 'plugins', $vendorsDir = 'vendors')
+    public static function determinePlugins($packages, $pluginsDir = 'plugins', $vendorDir = 'vendor')
     {
         $plugins = [];
 
@@ -142,7 +142,7 @@ class PluginInstaller extends LibraryInstaller
             }
 
             $ns = static::primaryNamespace($package);
-            $path = $vendorsDir . DIRECTORY_SEPARATOR . $package->getPrettyName();
+            $path = $vendorDir . DIRECTORY_SEPARATOR . $package->getPrettyName();
             $plugins[$ns] = $path;
         }
 
@@ -390,7 +390,7 @@ PHP;
     /**
      * Ensure that the vendor/cakephp-plugins.php file exists.
      *
-     * If config/plugins.php is found - copy it to the vendors folder
+     * If config/plugins.php is found - copy it to the vendor folder
      *
      * @param string $path the config file path.
      * @return void

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -3,8 +3,8 @@ namespace Cake\Composer\Installer;
 
 use Cake\Core\Configure\Engine\PhpConfig;
 use Composer\Composer;
-use Composer\IO\IOInterface;
 use Composer\Installer\LibraryInstaller;
+use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Script\Event;
@@ -40,7 +40,7 @@ class PluginInstaller extends LibraryInstaller
      * If not, warn the user they need to update their application's composer file.
      * Do nothing if the main project is not a project (if it's a plugin in development).
      *
-     * @param Composer $composer
+     * @param Composer $composer object
      * @return void
      */
     public function checkUsage(Composer $composer)

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -1,7 +1,6 @@
 <?php
 namespace Cake\Composer\Installer;
 
-use Cake\Core\Configure\Engine\PhpConfig;
 use Composer\Composer;
 use Composer\Installer\LibraryInstaller;
 use Composer\IO\IOInterface;

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -225,7 +225,7 @@ PHP;
      */
     protected static function configFile($root)
     {
-        return $root . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'plugins.php';
+        return $root . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'plugins.php';
     }
 
     /**
@@ -297,7 +297,7 @@ PHP;
      *
      * @param \Composer\Repository\InstalledRepositoryInterface $repo Repository in which to check.
      * @param \Composer\Package\PackageInterface $package Package instance.
-     * @deprecated use of the post-install-cmd hook is superceeded by the post-autoload-dump hook
+     * @deprecated superceeded by the post-autoload-dump hook
      */
     public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
@@ -316,7 +316,7 @@ PHP;
      * @param \Composer\Repository\InstalledRepositoryInterface $repo Repository in which to check.
      * @param \Composer\Package\PackageInterface $initial Already installed package version.
      * @param \Composer\Package\PackageInterface $target Updated version.
-     * @deprecated use of the post-install-cmd hook is superceeded by the post-autoload-dump hook
+     * @deprecated superceeded by the post-autoload-dump hook
      *
      * @throws \InvalidArgumentException if $initial package is not installed
      */
@@ -337,7 +337,7 @@ PHP;
      *
      * @param \Composer\Repository\InstalledRepositoryInterface $repo Repository in which to check.
      * @param \Composer\Package\PackageInterface $package Package instance.
-     * @deprecated use of the post-install-cmd hook is superceeded by the post-autoload-dump hook
+     * @deprecated superceeded by the post-autoload-dump hook
      */
     public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
@@ -365,7 +365,7 @@ PHP;
         }
         if (!isset($config)) {
             $this->io->write(
-                'ERROR - Your `config/plugins.php` did not define a $config variable. ' .
+                'ERROR - Your `vendor/plugins.php` did not define a $config variable. ' .
                 'Plugin path configuration not updated.'
             );
             return;
@@ -392,7 +392,7 @@ PHP;
     }
 
     /**
-     * Ensure that the config/plugins.php file exists.
+     * Ensure that the vendor/plugins.php file exists.
      *
      * @param string $path the config file path.
      * @return void
@@ -401,7 +401,7 @@ PHP;
     {
         if (file_exists($path)) {
             if ($this->io->isVerbose()) {
-                $this->io->write('config/plugins.php exists.');
+                $this->io->write('vendor/plugins.php exists.');
             }
             return;
         }
@@ -418,7 +418,7 @@ PHP;
         file_put_contents($path, $contents);
 
         if ($this->io->isVerbose()) {
-            $this->io->write('Created config/plugins.php');
+            $this->io->write('Created vendor/plugins.php');
         }
     }
 

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -73,18 +73,21 @@ class PluginInstaller extends LibraryInstaller
      */
     public function warnUpdateRequired()
     {
-        $emptyLine = sprintf('<error>%s</error>', str_repeat(' ', 80));
+        $wrap = function($text, $width = 75) {
+            return '<error>     ' . str_pad($text, $width) . '</error>';
+        };
 
         $messages = [
             '',
             '',
-            $emptyLine,
-            '<error>     ' . str_pad('Action required!', 75) . '</error>',
-            $emptyLine,
-            '<error>     ' . str_pad('The CakePHP plugin installer has been changed, please update your', 75) . '</error>',
-            '<error>     ' . str_pad('application composer.json file to add the post-autoload-dump hook.', 75) . '</error>',
-            '<error>     ' . str_pad('See the changes in https://github.com/cakephp/app/pull/216 for more info.', 75) . '</error>',
-            $emptyLine,
+            $wrap(''),
+            $wrap('Action required!'),
+            $wrap(''),
+            $wrap('The CakePHP plugin installer has been changed, please update your'),
+            $wrap('application composer.json file to add the post-autoload-dump hook.'),
+            $wrap('See the changes in https://github.com/cakephp/app/pull/216 for more'),
+            $wrap('info.'),
+            $wrap(''),
             '',
             '',
         ];
@@ -133,7 +136,7 @@ class PluginInstaller extends LibraryInstaller
     {
         $plugins = [];
 
-        foreach($packages as $package) {
+        foreach ($packages as $package) {
             if ($package->getType() !== 'cakephp-plugin') {
                 continue;
             }
@@ -145,7 +148,7 @@ class PluginInstaller extends LibraryInstaller
 
         if (is_dir($pluginsDir)) {
             $dir = new \DirectoryIterator($pluginsDir);
-            foreach($dir as $info) {
+            foreach ($dir as $info) {
                 if (!$info->isDir() || $info->isDot()) {
                     continue;
                 }

--- a/tests/Installer/PluginInstaller.php
+++ b/tests/Installer/PluginInstaller.php
@@ -19,6 +19,6 @@ class PluginInstaller extends PluginInstallerSrc
     public static function configFile($root)
     {
         $root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'plugin-installer-test';
-        return $root . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'plugins.php';
+        return $root . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'plugins.php';
     }
 }

--- a/tests/Installer/PluginInstaller.php
+++ b/tests/Installer/PluginInstaller.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Cake\Test\Composer\Installer;
+
+use Cake\Composer\Installer\PluginInstaller as PluginInstallerSrc;
+
+/**
+ * Test double for static methods in PluginInstaller
+ */
+class PluginInstaller extends PluginInstallerSrc
+{
+
+    /**
+     * Overriden to return a test-config file
+     *
+     * @param string $root
+     * @return string path to test plugins config file
+     */
+    public static function configFile($root)
+    {
+        $root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'plugin-installer-test';
+        return $root . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'plugins.php';
+    }
+}

--- a/tests/Installer/PluginInstaller.php
+++ b/tests/Installer/PluginInstaller.php
@@ -19,6 +19,6 @@ class PluginInstaller extends PluginInstallerSrc
     public static function configFile($root)
     {
         $root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'plugin-installer-test';
-        return $root . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'plugins.php';
+        return $root . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'cakephp-plugins.php';
     }
 }

--- a/tests/Installer/PluginInstaller.php
+++ b/tests/Installer/PluginInstaller.php
@@ -13,10 +13,10 @@ class PluginInstaller extends PluginInstallerSrc
     /**
      * Overriden to return a test-config file
      *
-     * @param string $root
+     * @param string $vendorDir
      * @return string path to test plugins config file
      */
-    public static function configFile($root)
+    public static function configFile($vendorDir)
     {
         $root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'plugin-installer-test';
         return $root . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'cakephp-plugins.php';

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -20,7 +20,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
      *
      * @var string
      */
-    protected $testDirs = ['', 'config', 'plugins', 'plugins/Foo', 'plugins/Fee', 'plugins/Foe', 'plugins/Fum'];
+    protected $testDirs = ['', 'vendor', 'plugins', 'plugins/Foo', 'plugins/Fee', 'plugins/Foe', 'plugins/Fum'];
 
     /**
      * setUp
@@ -63,8 +63,8 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
         $dirs = array_reverse($this->testDirs);
 
-        if (is_file($this->path . '/config/plugins.php')) {
-            unlink($this->path . '/config/plugins.php');
+        if (is_file($this->path . '/vendor/plugins.php')) {
+            unlink($this->path . '/vendor/plugins.php');
         }
 
         foreach($dirs as $dir) {
@@ -231,7 +231,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
             'TheThing' => $this->path . '/vendors/cakephp/the-thing'
         ];
 
-        $path = $this->path . '/config/plugins.php';
+        $path = $this->path . '/vendor/plugins.php';
         PluginInstaller::writeConfigFile($path, $plugins);
 
         $this->assertFileExists($path);
@@ -271,8 +271,8 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
     public function testUpdateConfigNoConfigFile()
     {
         $this->installer->updateConfig('DebugKit', '/vendor/cakephp/DebugKit');
-        $this->assertFileExists($this->path . '/config/plugins.php');
-        $contents = file_get_contents($this->path . '/config/plugins.php');
+        $this->assertFileExists($this->path . '/vendor/plugins.php');
+        $contents = file_get_contents($this->path . '/vendor/plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'plugins' =>", $contents);
         $this->assertContains("'DebugKit' => '/vendor/cakephp/DebugKit/'", $contents);
@@ -280,7 +280,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdateConfigAddPathInvalidFile()
     {
-        file_put_contents($this->path . '/config/plugins.php', '<?php $foo = "DERP";');
+        file_put_contents($this->path . '/vendor/plugins.php', '<?php $foo = "DERP";');
 
         $this->io->expects($this->once())
             ->method('write');
@@ -290,12 +290,12 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
     public function testUpdateConfigAddPathFileExists()
     {
         file_put_contents(
-            $this->path . '/config/plugins.php',
+            $this->path . '/vendor/plugins.php',
             '<?php $config = ["plugins" => ["Bake" => "/some/path"]];'
         );
 
         $this->installer->updateConfig('DebugKit', '/vendor/cakephp/DebugKit');
-        $contents = file_get_contents($this->path . '/config/plugins.php');
+        $contents = file_get_contents($this->path . '/vendor/plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'plugins' =>", $contents);
         $this->assertContains("'DebugKit' => '/vendor/cakephp/DebugKit/'", $contents);
@@ -308,10 +308,10 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
      * @return void
      */
     public function testUpdateConfigAddRootPath() {
-        file_put_contents($this->path . '/config/plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
+        file_put_contents($this->path . '/vendor/plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
 
         $this->installer->updateConfig('DebugKit', $this->path . '/vendor/cakephp/debugkit');
-        $contents = file_get_contents($this->path . '/config/plugins.php');
+        $contents = file_get_contents($this->path . '/vendor/plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains('$baseDir = dirname(dirname(__FILE__));', $contents);
         $this->assertContains("'DebugKit' => \$baseDir . '/vendor/cakephp/debugkit/'", $contents);
@@ -325,12 +325,12 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
      */
     public function testUpdateConfigAddPath()
     {
-        file_put_contents($this->path . '/config/plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
+        file_put_contents($this->path . '/vendor/plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
 
         $this->installer->updateConfig('DebugKit', '/vendor/cakephp/debugkit');
         $this->installer->updateConfig('ADmad\JwtAuth', '/vendor/admad/cakephp-jwt-auth');
 
-        $contents = file_get_contents($this->path . '/config/plugins.php');
+        $contents = file_get_contents($this->path . '/vendor/plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'DebugKit' => '/vendor/cakephp/debugkit/'", $contents);
         $this->assertContains("'Bake' => '/some/path'", $contents);
@@ -344,11 +344,11 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
      */
     public function testUpdateConfigAddPathWindows()
     {
-        file_put_contents($this->path . '/config/plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
+        file_put_contents($this->path . '/vendor/plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
 
         $this->installer->updateConfig('DebugKit', '\vendor\cakephp\debugkit');
 
-        $contents = file_get_contents($this->path . '/config/plugins.php');
+        $contents = file_get_contents($this->path . '/vendor/plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'DebugKit' => '/vendor/cakephp/debugkit/'", $contents);
     }
@@ -361,12 +361,12 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
     public function testUpdateConfigRemovePath()
     {
         file_put_contents(
-            $this->path . '/config/plugins.php',
+            $this->path . '/vendor/plugins.php',
             '<?php $config = ["plugins" => ["Bake" => "/some/path"]];'
         );
 
         $this->installer->updateConfig('Bake', '');
-        $contents = file_get_contents($this->path . '/config/plugins.php');
+        $contents = file_get_contents($this->path . '/vendor/plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'plugins' =>", $contents);
         $this->assertNotContains("Bake", $contents);

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -63,8 +63,8 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
         $dirs = array_reverse($this->testDirs);
 
-        if (is_file($this->path . '/vendor/plugins.php')) {
-            unlink($this->path . '/vendor/plugins.php');
+        if (is_file($this->path . '/vendor/cakephp-plugins.php')) {
+            unlink($this->path . '/vendor/cakephp-plugins.php');
         }
 
         foreach($dirs as $dir) {
@@ -231,7 +231,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
             'TheThing' => $this->path . '/vendors/cakephp/the-thing'
         ];
 
-        $path = $this->path . '/vendor/plugins.php';
+        $path = $this->path . '/vendor/cakephp-plugins.php';
         PluginInstaller::writeConfigFile($path, $plugins);
 
         $this->assertFileExists($path);
@@ -271,8 +271,8 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
     public function testUpdateConfigNoConfigFile()
     {
         $this->installer->updateConfig('DebugKit', '/vendor/cakephp/DebugKit');
-        $this->assertFileExists($this->path . '/vendor/plugins.php');
-        $contents = file_get_contents($this->path . '/vendor/plugins.php');
+        $this->assertFileExists($this->path . '/vendor/cakephp-plugins.php');
+        $contents = file_get_contents($this->path . '/vendor/cakephp-plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'plugins' =>", $contents);
         $this->assertContains("'DebugKit' => '/vendor/cakephp/DebugKit/'", $contents);
@@ -280,7 +280,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdateConfigAddPathInvalidFile()
     {
-        file_put_contents($this->path . '/vendor/plugins.php', '<?php $foo = "DERP";');
+        file_put_contents($this->path . '/vendor/cakephp-plugins.php', '<?php $foo = "DERP";');
 
         $this->io->expects($this->once())
             ->method('write');
@@ -290,12 +290,12 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
     public function testUpdateConfigAddPathFileExists()
     {
         file_put_contents(
-            $this->path . '/vendor/plugins.php',
+            $this->path . '/vendor/cakephp-plugins.php',
             '<?php $config = ["plugins" => ["Bake" => "/some/path"]];'
         );
 
         $this->installer->updateConfig('DebugKit', '/vendor/cakephp/DebugKit');
-        $contents = file_get_contents($this->path . '/vendor/plugins.php');
+        $contents = file_get_contents($this->path . '/vendor/cakephp-plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'plugins' =>", $contents);
         $this->assertContains("'DebugKit' => '/vendor/cakephp/DebugKit/'", $contents);
@@ -308,10 +308,10 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
      * @return void
      */
     public function testUpdateConfigAddRootPath() {
-        file_put_contents($this->path . '/vendor/plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
+        file_put_contents($this->path . '/vendor/cakephp-plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
 
         $this->installer->updateConfig('DebugKit', $this->path . '/vendor/cakephp/debugkit');
-        $contents = file_get_contents($this->path . '/vendor/plugins.php');
+        $contents = file_get_contents($this->path . '/vendor/cakephp-plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains('$baseDir = dirname(dirname(__FILE__));', $contents);
         $this->assertContains("'DebugKit' => \$baseDir . '/vendor/cakephp/debugkit/'", $contents);
@@ -325,12 +325,12 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
      */
     public function testUpdateConfigAddPath()
     {
-        file_put_contents($this->path . '/vendor/plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
+        file_put_contents($this->path . '/vendor/cakephp-plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
 
         $this->installer->updateConfig('DebugKit', '/vendor/cakephp/debugkit');
         $this->installer->updateConfig('ADmad\JwtAuth', '/vendor/admad/cakephp-jwt-auth');
 
-        $contents = file_get_contents($this->path . '/vendor/plugins.php');
+        $contents = file_get_contents($this->path . '/vendor/cakephp-plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'DebugKit' => '/vendor/cakephp/debugkit/'", $contents);
         $this->assertContains("'Bake' => '/some/path'", $contents);
@@ -344,11 +344,11 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
      */
     public function testUpdateConfigAddPathWindows()
     {
-        file_put_contents($this->path . '/vendor/plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
+        file_put_contents($this->path . '/vendor/cakephp-plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
 
         $this->installer->updateConfig('DebugKit', '\vendor\cakephp\debugkit');
 
-        $contents = file_get_contents($this->path . '/vendor/plugins.php');
+        $contents = file_get_contents($this->path . '/vendor/cakephp-plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'DebugKit' => '/vendor/cakephp/debugkit/'", $contents);
     }
@@ -361,12 +361,12 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
     public function testUpdateConfigRemovePath()
     {
         file_put_contents(
-            $this->path . '/vendor/plugins.php',
+            $this->path . '/vendor/cakephp-plugins.php',
             '<?php $config = ["plugins" => ["Bake" => "/some/path"]];'
         );
 
         $this->installer->updateConfig('Bake', '');
-        $contents = file_get_contents($this->path . '/vendor/plugins.php');
+        $contents = file_get_contents($this->path . '/vendor/cakephp-plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'plugins' =>", $contents);
         $this->assertNotContains("Bake", $contents);

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -309,7 +309,10 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
      */
     public function testUpdateConfigAddRootPath()
     {
-        file_put_contents($this->path . '/vendor/cakephp-plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
+        file_put_contents(
+            $this->path . '/vendor/cakephp-plugins.php',
+            '<?php return ["plugins" => ["Bake" => "/some/path"]];'
+        );
 
         $this->installer->updateConfig('DebugKit', $this->path . '/vendor/cakephp/debugkit');
         $contents = file_get_contents($this->path . '/vendor/cakephp-plugins.php');
@@ -326,7 +329,10 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
      */
     public function testUpdateConfigAddPath()
     {
-        file_put_contents($this->path . '/vendor/cakephp-plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
+        file_put_contents(
+            $this->path . '/vendor/cakephp-plugins.php',
+            '<?php return ["plugins" => ["Bake" => "/some/path"]];'
+        );
 
         $this->installer->updateConfig('DebugKit', '/vendor/cakephp/debugkit');
         $this->installer->updateConfig('ADmad\JwtAuth', '/vendor/admad/cakephp-jwt-auth');
@@ -345,7 +351,10 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
      */
     public function testUpdateConfigAddPathWindows()
     {
-        file_put_contents($this->path . '/vendor/cakephp-plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
+        file_put_contents(
+            $this->path . '/vendor/cakephp-plugins.php',
+            '<?php return ["plugins" => ["Bake" => "/some/path"]];'
+        );
 
         $this->installer->updateConfig('DebugKit', '\vendor\cakephp\debugkit');
 

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -35,7 +35,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
 
         $this->path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'plugin-installer-test';
 
-        foreach($this->testDirs as $dir) {
+        foreach ($this->testDirs as $dir) {
             if (!is_dir($this->path . '/' . $dir)) {
                 mkdir($this->path . '/' . $dir);
             }
@@ -67,7 +67,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
             unlink($this->path . '/vendor/cakephp-plugins.php');
         }
 
-        foreach($dirs as $dir) {
+        foreach ($dirs as $dir) {
             if (is_dir($this->path . '/' . $dir)) {
                 rmdir($this->path . '/' . $dir);
             }
@@ -256,7 +256,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         );
 
         // Ensure all plugin paths are slash terminated
-        foreach($plugins as &$plugin) {
+        foreach ($plugins as &$plugin) {
             $plugin .= '/';
         }
         unset ($plugin);
@@ -307,7 +307,8 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    public function testUpdateConfigAddRootPath() {
+    public function testUpdateConfigAddRootPath()
+    {
         file_put_contents($this->path . '/vendor/cakephp-plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
 
         $this->installer->updateConfig('DebugKit', $this->path . '/vendor/cakephp/debugkit');

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -20,7 +20,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
      *
      * @var string
      */
-    protected $testDirs = ['config', 'plugins', 'plugins/Foo', 'plugins/Fee', 'plugins/Foe', 'plugins/Fum'];
+    protected $testDirs = ['', 'config', 'plugins', 'plugins/Foo', 'plugins/Fee', 'plugins/Foe', 'plugins/Fum'];
 
     /**
      * setUp

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Cake\Test\TestCase\Composer\Installer;
 
-use Cake\Composer\Installer\PluginInstaller;
+use Cake\Test\Composer\Installer\PluginInstaller;
 use Composer\Composer;
 use Composer\Config;
 use Composer\Package\Package;
@@ -26,7 +26,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $this->package = new Package('CamelCased', '1.0', '1.0');
         $this->package->setType('cakephp-plugin');
 
-        $this->path = sys_get_temp_dir();
+        $this->path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'plugin-installer-test';
         if (!is_dir($this->path . '/config')) {
             mkdir($this->path . '/config');
         }
@@ -58,6 +58,20 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Sanity test
+     *
+     * The test double should return a path to a test file, where
+     * the containing folder
+     *
+     * @return void
+     */
+    public function testConfigFile()
+    {
+        $path = PluginInstaller::configFile("");
+        $this->assertFileExists(dirname($path));
+    }
+
+    /**
      * Ensure that primary namespace detection works.
      *
      * @return void
@@ -71,7 +85,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         );
         $this->package->setAutoload($autoload);
 
-        $ns = $this->installer->primaryNamespace($this->package);
+        $ns = PluginInstaller::primaryNamespace($this->package);
         $this->assertEquals('FOC\Authenticate', $ns);
 
         $autoload = array(
@@ -81,7 +95,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
             )
         );
         $this->package->setAutoload($autoload);
-        $ns = $this->installer->primaryNamespace($this->package);
+        $ns = PluginInstaller::primaryNamespace($this->package);
         $this->assertEquals('FOC\Acl', $ns);
 
         $autoload = array(
@@ -91,7 +105,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
             )
         );
         $this->package->setAutoload($autoload);
-        $ns = $this->installer->primaryNamespace($this->package);
+        $ns = PluginInstaller::primaryNamespace($this->package);
         $this->assertEquals('Acme\Plugin', $ns);
 
         $autoload = array(
@@ -101,7 +115,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
             )
         );
         $this->package->setAutoload($autoload);
-        $ns = $this->installer->primaryNamespace($this->package);
+        $ns = PluginInstaller::primaryNamespace($this->package);
         $this->assertEquals('Foo', $ns);
 
         $autoload = array(
@@ -111,7 +125,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
             )
         );
         $this->package->setAutoload($autoload);
-        $ns = $this->installer->primaryNamespace($this->package);
+        $ns = PluginInstaller::primaryNamespace($this->package);
         $this->assertEquals('Foo', $ns);
 
         $autoload = array(
@@ -121,7 +135,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
             )
         );
         $this->package->setAutoload($autoload);
-        $ns = $this->installer->primaryNamespace($this->package);
+        $ns = PluginInstaller::primaryNamespace($this->package);
         $this->assertEquals('Acme\Foo', $ns);
 
         $autoload = array(
@@ -131,7 +145,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
             )
         );
         $this->package->setAutoload($autoload);
-        $name = $this->installer->primaryNamespace($this->package);
+        $name = PluginInstaller::primaryNamespace($this->package);
         $this->assertEquals('Acme\Foo', $name);
     }
 
@@ -177,7 +191,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
     public function testUpdateConfigAddRootPath() {
         file_put_contents($this->path . '/config/plugins.php', '<?php return ["plugins" => ["Bake" => "/some/path"]];');
 
-        $this->installer->updateConfig('DebugKit', sys_get_temp_dir() . '/vendor/cakephp/debugkit');
+        $this->installer->updateConfig('DebugKit', $this->path . '/vendor/cakephp/debugkit');
         $contents = file_get_contents($this->path . '/config/plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains('$baseDir = dirname(dirname(__FILE__));', $contents);

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -193,19 +193,19 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $return = PluginInstaller::determinePlugins(
             $packages,
             $this->path . '/doesnt-exist',
-            $this->path . '/vendors'
+            $this->path . '/vendor'
         );
 
         $expected = [
-            'Princess' => $this->path . '/vendors/cakephp/princess',
-            'TheThing' => $this->path . '/vendors/cakephp/the-thing'
+            'Princess' => $this->path . '/vendor/cakephp/princess',
+            'TheThing' => $this->path . '/vendor/cakephp/the-thing'
         ];
         $this->assertSame($expected, $return, 'Only composer-loaded plugins should be listed');
 
         $return = PluginInstaller::determinePlugins(
             $packages,
             $this->path . '/plugins',
-            $this->path . '/vendors'
+            $this->path . '/vendor'
         );
 
         $expected = [
@@ -213,8 +213,8 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
             'Foe' => $this->path . '/plugins/Foe',
             'Foo' => $this->path . '/plugins/Foo',
             'Fum' => $this->path . '/plugins/Fum',
-            'Princess' => $this->path . '/vendors/cakephp/princess',
-            'TheThing' => $this->path . '/vendors/cakephp/the-thing'
+            'Princess' => $this->path . '/vendor/cakephp/princess',
+            'TheThing' => $this->path . '/vendor/cakephp/the-thing'
         ];
         $this->assertSame($expected, $return, 'Composer and application plugins should be listed');
     }
@@ -227,8 +227,8 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
             'Foo' => $this->path . '/plugins/Foo',
             'Fum' => $this->path . '/plugins/Fum',
             'OddOneOut' => '/some/other/path',
-            'Princess' => $this->path . '/vendors/cakephp/princess',
-            'TheThing' => $this->path . '/vendors/cakephp/the-thing'
+            'Princess' => $this->path . '/vendor/cakephp/princess',
+            'TheThing' => $this->path . '/vendor/cakephp/the-thing'
         ];
 
         $path = $this->path . '/vendor/cakephp-plugins.php';
@@ -245,7 +245,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
             'paths should be relative for app-plugins'
         );
         $this->assertContains(
-            "'Princess' => \$baseDir . '/vendors/cakephp/princess/'",
+            "'Princess' => \$baseDir . '/vendor/cakephp/princess/'",
             $contents,
             'paths should be relative for vendor-plugins'
         );

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -261,7 +261,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         }
         unset ($plugin);
 
-        $result = require($path);
+        $result = require $path;
         $expected = [
             'plugins' => $plugins
         ];


### PR DESCRIPTION
This allows the plugin information to be fresh whenever the autoloader is dumped.

A follow up to this would be to then add to cakephp/app's composer file:

     "pre-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"

~~Removing the post-install-cmd and~~ (derp) deleting all the instance methods in this class since they would then be unused.

And we could also move the plugins file from `config/plugins.php` to `vendors/cakephp-plugins.php` or similar.

_should_ this code remain in this repo? It could be moved to cakephp's Plugin class if preferred.