### PR TITLE
Removing trailing slash from path.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Cake\\Composer\\": "src/"
+            "Cake\\Composer\\": "src"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
Refs #23.

Given the double slash seen in path, hopefully this should fix the issue.