### PR TITLE
Fix paths at source

### DIFF
--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -116,7 +116,7 @@ class PluginInstaller extends LibraryInstaller
         $composer = $event->getComposer();
         $config = $composer->getConfig();
 
-        $vendorDir = $config->get('vendor-dir');
+        $vendorDir = realpath($config->get('vendor-dir'));
 
         $packages = $composer->getRepositoryManager()->getLocalRepository()->getPackages();
         $pluginsDir = dirname($vendorDir) . DIRECTORY_SEPARATOR . 'plugins';
@@ -190,9 +190,6 @@ class PluginInstaller extends LibraryInstaller
             // Normalize to *nix paths.
             $pluginPath = str_replace('\\', '/', $pluginPath);
             $pluginPath .= '/';
-            if ($pluginPath[0] !== '/' && DIRECTORY_SEPARATOR === '/') {
-                $pluginPath = '/' . $pluginPath;
-            }
 
             // Namespaced plugins should use /
             $name = str_replace('\\', '/', $name);


### PR DESCRIPTION
As discussed with @AD7six over IRC, this fixes an issue with composer's `$config->get('vendor-dir')` sometimes returning relative paths whereas the code expects it to be an absolute path at all times.

See https://github.com/composer/composer/blob/master/src/Composer/Config.php#L180