### PR TITLE
Use single quoted strings to fix config file generation.

### DIFF
--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -307,7 +307,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('<?php', $contents);
         $this->assertContains("'plugins' =>", $contents);
         $this->assertContains("'DebugKit' => '/vendor/cakephp/DebugKit/'", $contents);
-        $this->assertContains("'Bake' => '/some/path'", $contents);
+        $this->assertContains("'Bake' => '/some/path/'", $contents);
     }
 
     /**
@@ -327,7 +327,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('<?php', $contents);
         $this->assertContains('$baseDir = dirname(dirname(__FILE__));', $contents);
         $this->assertContains("'DebugKit' => \$baseDir . '/vendor/cakephp/debugkit/'", $contents);
-        $this->assertContains("'Bake' => '/some/path'", $contents);
+        $this->assertContains("'Bake' => '/some/path/'", $contents);
     }
 
     /**
@@ -348,7 +348,7 @@ class PluginInstallerTest extends \PHPUnit_Framework_TestCase
         $contents = file_get_contents($this->path . '/vendor/cakephp-plugins.php');
         $this->assertContains('<?php', $contents);
         $this->assertContains("'DebugKit' => '/vendor/cakephp/debugkit/'", $contents);
-        $this->assertContains("'Bake' => '/some/path'", $contents);
+        $this->assertContains("'Bake' => '/some/path/'", $contents);
         $this->assertContains("'ADmad/JwtAuth' => '/vendor/admad/cakephp-jwt-auth/'", $contents);
     }
 


### PR DESCRIPTION
The config file templates can't use "" as constants are interpolated into those strings by PHP. Instead we have to use '' strings. This change also removes the duplicated templates as having 3 copies of the template made this problem much harder to track down and fix.

Refs #30