### PR TITLE
Allow specifying plugin paths through app's composer.json.

### DIFF
--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -167,6 +167,10 @@ class PluginInstaller extends LibraryInstaller
                     }
 
                     $name = $info->getFilename();
+                    if ($name{0} === '.') {
+                        continue;
+                    }
+
                     $plugins[$name] = $path . DIRECTORY_SEPARATOR . $name;
                 }
             }

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -119,7 +119,12 @@ class PluginInstaller extends LibraryInstaller
         $vendorDir = realpath($config->get('vendor-dir'));
 
         $packages = $composer->getRepositoryManager()->getLocalRepository()->getPackages();
-        $pluginsDir = dirname($vendorDir) . DIRECTORY_SEPARATOR . 'plugins';
+        $extra = $event->getComposer()->getPackage()->getExtra();
+        if (empty($extra['plugin-paths'])) {
+            $pluginsDir = dirname($vendorDir) . DIRECTORY_SEPARATOR . 'plugins';
+        } else {
+            $pluginsDir = $extra['plugin-paths'];
+        }
 
         $plugins = static::determinePlugins($packages, $pluginsDir, $vendorDir);
 
@@ -134,7 +139,7 @@ class PluginInstaller extends LibraryInstaller
      * in the plugins directory to a plugin-name indexed array of paths
      *
      * @param array $packages an array of \Composer\Package\PackageInterface objects
-     * @param string $pluginsDir the path to the plugins dir
+     * @param string|array $pluginsDir the path to the plugins dir
      * @param string $vendorDir the path to the vendor dir
      * @return array plugin-name indexed paths to plugins
      */
@@ -152,21 +157,44 @@ class PluginInstaller extends LibraryInstaller
             $plugins[$ns] = $path;
         }
 
-        if (is_dir($pluginsDir)) {
-            $dir = new \DirectoryIterator($pluginsDir);
-            foreach ($dir as $info) {
-                if (!$info->isDir() || $info->isDot()) {
-                    continue;
-                }
+        foreach ((array)$pluginsDir as $path) {
+            $path = static::fullpath($path, $vendorDir);
+            if (is_dir($path)) {
+                $dir = new \DirectoryIterator($path);
+                foreach ($dir as $info) {
+                    if (!$info->isDir() || $info->isDot()) {
+                        continue;
+                    }
 
-                $name = $info->getFilename();
-                $plugins[$name] = $pluginsDir . DIRECTORY_SEPARATOR . $name;
+                    $name = $info->getFilename();
+                    $plugins[$name] = $path . DIRECTORY_SEPARATOR . $name;
+                }
             }
         }
 
         ksort($plugins);
 
         return $plugins;
+    }
+
+    /**
+     * Turns relative paths in full paths.
+     *
+     * @param string $path Path
+     * @param string $vendorDir The path to the vendor dir
+     * @return string
+     */
+    protected static function fullpath($path, $vendorDir)
+    {
+        if (preg_match('{^(?:/|[a-z]:|[a-z0-9.]+://)}i', $path)) {
+            return rtrim($path, '/');
+        }
+
+        if (substr($path, 0, 2) === './') {
+            $path = substr($path, 2);
+        }
+
+        return rtrim(dirname($vendorDir) . DIRECTORY_SEPARATOR . $path);
     }
 
     /**

--- a/tests/TestCase/Installer/PluginInstallerTest.php
+++ b/tests/TestCase/Installer/PluginInstallerTest.php
@@ -19,7 +19,17 @@ class PluginInstallerTest extends TestCase
      *
      * @var string
      */
-    protected $testDirs = ['', 'vendor', 'plugins', 'plugins/Foo', 'plugins/Fee', 'plugins/Foe', 'plugins/Fum'];
+    protected $testDirs = [
+        '',
+        'vendor',
+        'plugins',
+        'plugins/Foo',
+        'plugins/Fee',
+        'plugins/Foe',
+        'plugins/Fum',
+        'app_plugins',
+        'app_plugins/Bar',
+    ];
 
     /**
      * setUp
@@ -208,6 +218,23 @@ class PluginInstallerTest extends TestCase
         );
 
         $expected = [
+            'Fee' => $this->path . '/plugins/Fee',
+            'Foe' => $this->path . '/plugins/Foe',
+            'Foo' => $this->path . '/plugins/Foo',
+            'Fum' => $this->path . '/plugins/Fum',
+            'Princess' => $this->path . '/vendor/cakephp/princess',
+            'TheThing' => $this->path . '/vendor/cakephp/the-thing'
+        ];
+        $this->assertSame($expected, $return, 'Composer and application plugins should be listed');
+
+        $return = PluginInstaller::determinePlugins(
+            $packages,
+            [$this->path . '/plugins', $this->path . '/app_plugins'],
+            $this->path . '/vendor'
+        );
+
+        $expected = [
+            'Bar' => $this->path . '/app_plugins/Bar',
             'Fee' => $this->path . '/plugins/Fee',
             'Foe' => $this->path . '/plugins/Foe',
             'Foo' => $this->path . '/plugins/Foo',


### PR DESCRIPTION
For e.g.
```
"extra": {
    "plugin-paths": ["plugins", "extra_plugins"]
}
```

Currently while you can configure the paths cake should look under for plugins, the plugin path is hardcoded in plugin installer. Hence plugins under any extra/non default path don't get added to `cakephp-plugins.php`.