### PR TITLE
Exclude files from being exported

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,8 @@
 # Set default behaviour, in case users don't have core.autocrlf set.
 * text=auto
 * text eol=lf
+
+# Remove files for archives generated using `git archive`
+.editorconfig export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
I was toying around with a deployment script and noticed these unnecessary (in a deployment context) files.