### PR TITLE
Make Plugin class final

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,7 +9,7 @@ use Composer\Plugin\PluginInterface;
 use Composer\Script\Event;
 use RuntimeException;
 
-class Plugin implements PluginInterface, EventSubscriberInterface
+final class Plugin implements PluginInterface, EventSubscriberInterface
 {
     /**
      * @inheritDoc


### PR DESCRIPTION
This will hopefully prevent the unsupported scenario of a user app/plugin inheriting plugin installer.  Users won't run into awkward situations when the implementation changes.