### PR TITLE
Add autoload paths for app plugins.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 * text eol=lf
 
 # Remove files for archives generated using `git archive`
+.phive export-ignore
 .editorconfig export-ignore
 phpunit.xml.dist export-ignore
 phpcs.xml.dist export-ignore

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phive xmlns="https://phar.io/phive">
+    <phar name="phpstan" version="1.10.13" installed="1.10.13" location="./tools/phpstan" copy="false"/>
+    <phar name="psalm" version="5.9.0" installed="5.9.0" location="./tools/psalm" copy="false"/>
+</phive>

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -63,9 +63,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $extra['plugin-paths'] = ['plugins'];
         }
 
-        $root = dirname(realpath($event->getComposer()->getConfig()->get('vendor-dir')));
+        $root = dirname(realpath($event->getComposer()->getConfig()->get('vendor-dir'))) . '/';
         foreach ($extra['plugin-paths'] as $pluginsPath) {
-            foreach (new DirectoryIterator($root . '/' . $pluginsPath) as $fileInfo) {
+            foreach (new DirectoryIterator($root . $pluginsPath) as $fileInfo) {
                 if (!$fileInfo->isDir() || $fileInfo->isDot()) {
                     continue;
                 }
@@ -78,10 +78,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface
                 $pluginNamespace = $folderName . '\\';
                 $pluginTestNamespace = $folderName . '\\Test\\';
                 $path = $pluginsPath . '/' . $folderName . '/';
-                if (!isset($autoload['psr-4'][$pluginNamespace])) {
+                if (!isset($autoload['psr-4'][$pluginNamespace]) && is_dir($root . $path . '/src')) {
                     $autoload['psr-4'][$pluginNamespace] = $path . 'src';
                 }
-                if (!isset($devAutoload['psr-4'][$pluginTestNamespace])) {
+                if (!isset($devAutoload['psr-4'][$pluginTestNamespace]) && is_dir($root . $path . '/tests')) {
                     $devAutoload['psr-4'][$pluginTestNamespace] = $path . 'tests';
                 }
             }

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -33,15 +33,14 @@ class PluginTest extends TestCase
      * @var array<string>
      */
     protected array $testDirs = [
-        '',
         'vendor',
-        'plugins',
         'plugins/Foo',
-        'plugins/Fee',
-        'plugins/Foe',
+        'plugins/Fee/src',
+        'plugins/Fee/tests',
+        'plugins/Foe/src',
         'plugins/Fum',
-        'app_plugins',
-        'app_plugins/Bar',
+        'app_plugins/Bar/src',
+        'app_plugins/Bar/tests',
     ];
 
     protected string $path;
@@ -62,7 +61,7 @@ class PluginTest extends TestCase
 
         foreach ($this->testDirs as $dir) {
             if (!is_dir($this->path . '/' . $dir)) {
-                mkdir($this->path . '/' . $dir);
+                mkdir($this->path . '/' . $dir, 0777, true);
             }
         }
 
@@ -96,16 +95,10 @@ class PluginTest extends TestCase
     {
         parent::tearDown();
 
-        $dirs = array_reverse($this->testDirs);
-
-        if (is_file($this->path . '/vendor/cakephp-plugins.php')) {
-            unlink($this->path . '/vendor/cakephp-plugins.php');
-        }
-
-        foreach ($dirs as $dir) {
-            if (is_dir($this->path . '/' . $dir)) {
-                rmdir($this->path . '/' . $dir);
-            }
+        if (PHP_OS === 'Windows') {
+            exec(sprintf('rd /s /q %s', escapeshellarg($this->path)));
+        } else {
+            exec(sprintf('rm -rf %s', escapeshellarg($this->path)));
         }
     }
 
@@ -154,7 +147,6 @@ class PluginTest extends TestCase
             'psr-4' => [
                 'Foo\\' => 'xyz/Foo/src',
                 'Fee\\' => 'plugins/Fee/src',
-                'Fum\\' => 'plugins/Fum/src',
                 'Foe\\' => 'plugins/Foe/src',
                 'Bar\\' => 'app_plugins/Bar/src',
             ],
@@ -165,8 +157,6 @@ class PluginTest extends TestCase
             'psr-4' => [
                 'Foo\Test\\' => 'xyz/Foo/tests',
                 'Fee\Test\\' => 'plugins/Fee/tests',
-                'Fum\Test\\' => 'plugins/Fum/tests',
-                'Foe\Test\\' => 'plugins/Foe/tests',
                 'Bar\Test\\' => 'app_plugins/Bar/tests',
             ],
         ];


### PR DESCRIPTION
This change avoids having to update the app's composer.json to add autoload paths for app plugins under the "plugins" folder.

I have been using a custom composer plugin which does the same for quite a while for my apps.