### PR TITLE
2.x: fix error if plugin-paths contains unknown folder

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -65,6 +65,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
         $root = dirname(realpath($event->getComposer()->getConfig()->get('vendor-dir'))) . '/';
         foreach ($extra['plugin-paths'] as $pluginsPath) {
+            if (!is_dir($root . $pluginsPath)) {
+                continue;
+            }
             foreach (new DirectoryIterator($root . $pluginsPath) as $fileInfo) {
                 if (!$fileInfo->isDir() || $fileInfo->isDot()) {
                     continue;

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -163,6 +163,45 @@ class PluginTest extends TestCase
         $this->assertEquals($expected, $package->getDevAutoload());
     }
 
+    public function testPreAutoloadDumpNonExistentPluginPaths()
+    {
+        $package = new RootPackage('App', '1.0.0', '1.0.0');
+        $package->setExtra([
+            'plugin-paths' => [
+                'unknown_folder',
+            ],
+        ]);
+        $package->setAutoload([
+            'psr-4' => [
+                'Foo\\' => 'xyz/Foo/src',
+            ],
+        ]);
+        $package->setDevAutoload([
+            'psr-4' => [
+                'Foo\Test\\' => 'xyz/Foo/tests',
+            ],
+        ]);
+        $this->composer->setPackage($package);
+
+        $event = new Event('', $this->composer, $this->io);
+
+        $this->plugin->preAutoloadDump($event);
+
+        $expected = [
+            'psr-4' => [
+                'Foo\\' => 'xyz/Foo/src',
+            ],
+        ];
+        $this->assertEquals($expected, $package->getAutoload());
+
+        $expected = [
+            'psr-4' => [
+                'Foo\Test\\' => 'xyz/Foo/tests',
+            ],
+        ];
+        $this->assertEquals($expected, $package->getDevAutoload());
+    }
+
     public function testGetPrimaryNamespace()
     {
         $autoload = [


### PR DESCRIPTION
```
DirectoryIterator::__construct(/.../cakephp-ide-helper/plugins): Failed to open directory: No such file or directory
```

if `plugin-paths` contains a path/folder which doesn't exist